### PR TITLE
Increased grafana verbosity level

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,8 @@ services:
     image: grafana/grafana:6.5.2
     ports:
       - "3000:3000"
+    environment:
+      GF_LOG_LEVEL: debug
     volumes:
       - /var/lib/grafana
       - .:/var/lib/grafana/plugins/cassandra


### PR DESCRIPTION
Set grafana LogLevel to Debug

- Review changeset
- Run locally to check grafana logs
- Expected: grafana has `lvl=dbug` messages in log output

![image](https://user-images.githubusercontent.com/1742301/72225579-515b0c80-3587-11ea-9925-64346276a3f1.png)
