### PR TITLE
Provide a slightly more general Cassandra query

### DIFF
--- a/backend/datasource.go
+++ b/backend/datasource.go
@@ -90,9 +90,9 @@ func (ds *CassandraDatasource) MetricQuery(tsdbReq *datasource.DatasourceRequest
 		serie := &datasource.TimeSeries{Name: queryData.Get("valueId").MustString()}
 
 		var created_at time.Time
-		var value int
+		var value float64
 		preparedQuery := fmt.Sprintf(
-			"SELECT %s, %s FROM %s.%s WHERE %s = %s", 
+			"SELECT %s, CAST(%s as double) FROM %s.%s WHERE %s = %s ALLOW FILTERING",
 			queryData.Get("columnTime").MustString(),
 			queryData.Get("columnValue").MustString(),
 			queryData.Get("keyspace").MustString(),
@@ -104,7 +104,7 @@ func (ds *CassandraDatasource) MetricQuery(tsdbReq *datasource.DatasourceRequest
 		for iter.Scan(&created_at, &value) {
 			serie.Points = append(serie.Points, &datasource.Point{
 				Timestamp: created_at.UnixNano() / int64(time.Millisecond),
-				Value:     float64(value),
+				Value:     value,
 			})
 		}
 		if err := iter.Close(); err != nil {


### PR DESCRIPTION
Widen the value type to double. Use CAST() to convert it if needed.
Add 'allow filtering' to provide for the case where there is a composite primary key,
albeit with the performance degradation associated with this clause.